### PR TITLE
Resolves #2: Update to a generic license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,35 +1,32 @@
 # Copyright
 
-&copy; Copyright 2020, 2021 Chris Szalwinski and Seneca College
+&copy; Copyright 2022 Seneca College
 
 # LICENSE
 
-NOTE: this repository is a derivative work based on https://ict.senecacollege.ca/~oop345 which was designed by Chris Szalwinski, Professor, Seneca College, Toronto, Canada.
-
 ## Documentation
 
-Except where otherwise noted, all documentation on this site is &copy; Copyright 2020 Chris Szalwinski and Seneca College and may be used in accordance with the Creative Commons License, Attribution 2.5. This copyleft license allows you to copy, modify, and redistribute modifications of all or some of the pages as long as you
+Except where otherwise noted, all documentation on this site is &copy; Copyright 2022 Seneca College and may be used in accordance with the Creative Commons License, Attribution 2.5. This copyleft license allows you to copy, modify, and redistribute modifications of all or some of the pages as long as you
 
 1. include the license with all copies or redistributions
-1. attribute Chris Szalwinski and Seneca College as the copyright holders
 
 ## Creative Commons License
 
-This Web Site by Chris Szalwinski is licensed under a Creative Commons Attribution 2.5 Canada License.
+This Web Site by Seneca College is licensed under a Creative Commons Attribution 2.5 Canada License.
 
 ## Software
 
-Except where otherwise noted, all software downloadable from this site is &copy; Copyright 2020 Chris Szalwinski and Seneca College and may be used in accordance with the PostgreSQL License (TPL):
+Except where otherwise noted, all software downloadable from this site is &copy; Copyright 2022 Seneca College and may be used in accordance with the PostgreSQL License (TPL):
 
 > Permission to use, copy, modify, and distribute this software and its documentation for any purpose, without fee, and without a written agreement is hereby granted, provided that the above copyright notice and this paragraph and the following two paragraphs appear in all copies.
 >
-> IN NO EVENT SHALL Chris Szalwinski or Seneca College BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF Chris Szalwinski or Seneca College HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+> IN NO EVENT SHALL Seneca College BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF Seneca College HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 >
-> Chris Szalwinski and Seneca College SPECIFICALLY DISCLAIM ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND Chris Szalwinski and Seneca College HAVE NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+> Seneca College SPECIFICALLY DISCLAIM ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND Seneca College HAVE NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 This permissive license allows you to copy, modify, and redistribute modifications of all or some of the software as long as you
 
 1. include the license with all copies or redistributions
-1. attribute Chris Szalwinski and Seneca College as the copyright holders
+1. attribute Seneca College as the copyright holders
 
 Please direct any comments regarding this site or the software downloadable from this site here.


### PR DESCRIPTION
Resolves #2: Update to a generic license
@catherine-leung :  Removed references to any specific person and generalizes to Seneca as the owner.  Maintains a copy-left requirement.