### PR TITLE
Pdf generation

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -34,6 +34,9 @@ jobs:
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
 
+      # erase everything below this comment if you do not wish to generate a pdf for the OER
+      # If you want to generate a pdf, alter lines 55 and 58.
+
       - uses: actions/checkout@v4
         with:
           ref: gh-pages

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -33,3 +33,28 @@ jobs:
           # You can swap them out with your own user credentials.
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
+
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Install Prince
+        run: |
+          curl https://www.princexml.com/download/prince-14.2-linux-generic-x86_64.tar.gz -O
+          tar zxf prince-14.2-linux-generic-x86_64.tar.gz
+          cd prince-14.2-linux-generic-x86_64
+          yes "" | sudo ./install.sh
+
+      - name: Build PDF
+        run: npx docusaurus-prince-pdf -u https://seneca-ictoer.github.io/OERTemplate/
+
+      - name: rename
+        run: mv ./pdf/seneca-ictoer.github.io-OERTemplate.pdf ./pdf/OERTemplate.pdf
+
+      - name: Push pdf
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add ./pdf
+          git commit -m "add pdf file"
+          git push origin gh-pages

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ To generate a repository secret for the deployment script:
   - Change the name field to match your repo name
 - docusaurus.config.js
   - Multiple fields that refer to this template needs to change to refer to your repository
+- .github/workflows/deployment.yml
+  - the deployment script includes a pdf generator
+  - if you wish to generate a pdf version of the notes:
+    - modify lines 55 and 58 to match your repo url and pdf file names
+    - Note that that the pdf generator blurb with link to prince-pdf in intro.md is required as part of the licencing terms, so do not erase it.
+  - if you do not wish to use the pdf generator:
+    - erase lines 39 - the end of file.
+    - alter docs/intro.md and erase the two sections related to pdf and pdf generator
 
 ## Files You Should Review
 

--- a/docs/A-Introduction/_category_.json
+++ b/docs/A-Introduction/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Introduction",
-  "position": 2
+  "position": 3
 }

--- a/docs/B-SubSection2/_category_.json
+++ b/docs/B-SubSection2/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "SubSection3",
-  "position": 3
+  "position": 4
 }

--- a/docs/C-SubSection3/_category_.json
+++ b/docs/C-SubSection3/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "SubSection3",
-  "position": 4
+  "position": 5
 }

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,27 +1,21 @@
 ---
 id: intro
-title: Table of contents
+title: Introduction
 sidebar_position: 1
 slug: /
 description: Contents of (course notes title here)
 ---
 
-# Table of contents
+# Introduction
 
-## Introduction <a id="part-a-introduction"></a>
+This is a demonstration of a docusaurus template that we use to create OER's.
 
-- [Test Page](A-Introduction/testfile.md)
-- [Topic 2](A-Introduction/topic-file-2.md)
-- [Topic 3](A-Introduction/topic-file-3.md)
+## PDF version of these notes:
 
-## SubSection2
+A pdf version of these notes can be found here:
 
-- [Topic 1](B-SubSection2/topic-file-1.md)
-- [Topic 2](B-SubSection2/topic-file-2.md)
-- [Topic 3](B-SubSection2/topic-file-3.md)
+https://seneca-ictoer.github.io/OERTemplate/pdf/OERTemplate.pdf
 
-## SubSection3
+## PDF Generator
 
-- [Topic 1](C-SubSection3/topic-file-1.md)
-- [Topic 2](C-SubSection3/topic-file-2.md)
-- [Topic 3](C-SubSection3/topic-file-3.md)
+The pdf version of these notes were created using pdf-prince plugin and Prince 14 which is available here: http://www.princexml.com/

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,7 +14,7 @@ This is a demonstration of a docusaurus template that we use to create OER's.
 
 A pdf version of these notes can be found here:
 
-https://seneca-ictoer.github.io/OERTemplate/pdf/OERTemplate.pdf
+[pdf version of these notes](pdf/OERTemplate.pdf)
 
 ## PDF Generator
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -1,0 +1,27 @@
+---
+id: toc
+title: Table of contents
+sidebar_position: 2
+slug: /toc
+description: Contents of (course notes title here)
+---
+
+# Table of contents
+
+## Introduction <a id="part-a-introduction"></a>
+
+- [Test Page](A-Introduction/testfile.md)
+- [Topic 2](A-Introduction/topic-file-2.md)
+- [Topic 3](A-Introduction/topic-file-3.md)
+
+## SubSection2
+
+- [Topic 1](B-SubSection2/topic-file-1.md)
+- [Topic 2](B-SubSection2/topic-file-2.md)
+- [Topic 3](B-SubSection2/topic-file-3.md)
+
+## SubSection3
+
+- [Topic 1](C-SubSection3/topic-file-1.md)
+- [Topic 2](C-SubSection3/topic-file-2.md)
+- [Topic 3](C-SubSection3/topic-file-3.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,13 +7,13 @@ const katex = require('rehype-katex');
 module.exports = {
   title: 'OER Course Title',
   tagline: 'OER Tag/Keyword',
-  url: 'https://Seneca-ICTOER.github.io/',
+  url: 'https://catherine-leung.github.io/',
   baseUrl: '/OERTemplate/',
   trailingSlash: false,
-  onBrokenLinks: 'ignore',
+  onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
-  organizationName: 'Seneca-ICTOER',
+  organizationName: 'catherine-leung',
   projectName: 'OERTemplate',
   themeConfig: {
     navbar: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ module.exports = {
   url: 'https://Seneca-ICTOER.github.io/',
   baseUrl: '/OERTemplate/',
   trailingSlash: false,
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'ignore',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'Seneca-ICTOER',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,7 +57,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: '/',
-          editUrl: 'https://github.com/Seneca-ICTOER/OERTemplate/tree/main',
+          editUrl: 'https://github.com/catherine-leung/OERTemplate/tree/main',
           remarkPlugins: [math],
           rehypePlugins: [katex],
         },


### PR DESCRIPTION
This patch adds automatic pdf generation to the template as per issue #12 

This patch uses pdf-prince to do this.

The following changes were made:

workflow/deployment.yml:

- installs prince to generate the pdf
- generate the pdf based on current deployment of OER
- change the name so that its not so long
- push the pdf into the gh-pages branch, pdf folder

intro.md 
- moved the table of contents to toc.md
- changed intro.md to be a "front page"
- front page includes introduction, link to the pdf version of the notes, link to prince (required as per licencing terms)

toc.md
- table of contents file which was the old intro.md file

various _category_json files to fix ordering

README.md
- added instructions to modify workflow based on whether whether to use pdf generation or not