### PR TITLE
Add feature: hideable sidebar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,6 +24,11 @@ module.exports = {
         srcDark: 'img/logo-dark.svg',
       },
     },
+    docs: {
+      sidebar: {
+        hideable: true,
+      },
+    },
     tableOfContents: {
       maxHeadingLevel: 4,
     },


### PR DESCRIPTION
Follow-up on https://github.com/Seneca-ICTOER/Intro2C/issues/182

## Changes

Added the following lines to `docusaurus.config.js`:

```js
docs: {
  sidebar: {
    hideable: true,
  },
},
```